### PR TITLE
Change alloc add worker name aiida -> ahq

### DIFF
--- a/aiida_hyperqueue/cli/alloc.py
+++ b/aiida_hyperqueue/cli/alloc.py
@@ -60,7 +60,7 @@ def cmd_add(
 
     with computer.get_transport() as transport:
         retval, _, stderr = transport.exec_command_wait(
-            f'hq alloc add slurm --backlog {backlog} --time-limit {time_limit} --name aiida {hyper} '
+            f'hq alloc add slurm --backlog {backlog} --time-limit {time_limit} --name ahq {hyper} '
             f'--workers-per-alloc {workers_per_alloc} -- {" ".join(slurm_options)}'
         )
 


### PR DESCRIPTION
Original name is `aiida-xx` for jobs, which is same as regular aiida job. I change it to `ahq` (i.e. aiida-hq) to distinguish it.
I don't think we need to let user able to change it. 