### PR TITLE
Place the --output-mode in front of job scritp

### DIFF
--- a/aiida_hyperqueue/scheduler.py
+++ b/aiida_hyperqueue/scheduler.py
@@ -148,7 +148,7 @@ class HyperQueueScheduler(Scheduler):
             submit_script: the path of the submit script relative to the working
                 directory.
         """
-        submit_command = f"hq submit {submit_script} --output-mode=json"
+        submit_command = f"hq submit --output-mode=json {submit_script}"
 
         self.logger.info(f"Submitting with: {submit_command}")
 
@@ -178,10 +178,10 @@ class HyperQueueScheduler(Scheduler):
                 f"in _parse_submit_output{transport_string}: there was some text in stderr: {stderr}"
             )
 
-        hq_job_dict = json.loads(stdout)
         try:
+            hq_job_dict = json.loads(stdout)
             return str(hq_job_dict["id"])
-        except KeyError:
+        except Exception:
             # If no valid line is found, log and raise an error
             self.logger.error(
                 f"in _parse_submit_output{transport_string}: unable to find the job id: {stdout}"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -69,7 +69,7 @@ def test_submit_command():
     """Test submit command"""
     scheduler = HyperQueueScheduler()
 
-    assert "hq submit job.sh" in scheduler._get_submit_command("job.sh")
+    assert "hq submit --output-mode=json job.sh" == scheduler._get_submit_command("job.sh")
 
 
 def test_parse_submit_command_output(hq_env: HqEnv, valid_submit_script):
@@ -78,8 +78,11 @@ def test_parse_submit_command_output(hq_env: HqEnv, valid_submit_script):
     hq_env.start_worker(cpus="1")
     Path("_aiidasubmit.sh").write_text(valid_submit_script)
 
+    scheduler = HyperQueueScheduler()
+    args = scheduler._get_submit_command("_aiidasubmit.sh")
+    args = args.split(' ')[1:]
     process = hq_env.command(
-        ["submit", "--output-mode=json", "_aiidasubmit.sh"],
+        args,
         wait=False,
         ignore_stderr=True,
     )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -69,7 +69,9 @@ def test_submit_command():
     """Test submit command"""
     scheduler = HyperQueueScheduler()
 
-    assert "hq submit --output-mode=json job.sh" == scheduler._get_submit_command("job.sh")
+    assert "hq submit --output-mode=json job.sh" == scheduler._get_submit_command(
+        "job.sh"
+    )
 
 
 def test_parse_submit_command_output(hq_env: HqEnv, valid_submit_script):
@@ -80,7 +82,7 @@ def test_parse_submit_command_output(hq_env: HqEnv, valid_submit_script):
 
     scheduler = HyperQueueScheduler()
     args = scheduler._get_submit_command("_aiidasubmit.sh")
-    args = args.split(' ')[1:]
+    args = args.split(" ")[1:]
     process = hq_env.command(
         args,
         wait=False,


### PR DESCRIPTION
Fixes #27

`--output-mode` option was wrongly put in the end of the submit command which cause the problem that stdout of submit command is not json parsable. The test was not able to catch it because the command was defined in the test but not directly get from the scheduler. Test is update to using the commond generated from scheduler and therefore being tested directly.