### PR TITLE
Change `id` field passed to JobInfo from int to str

### DIFF
--- a/aiida_hyperqueue/scheduler.py
+++ b/aiida_hyperqueue/scheduler.py
@@ -228,7 +228,7 @@ class HyperQueueScheduler(Scheduler):
         job_info_list = []
         for hq_job_dict in hq_job_info_list:
             job_info = JobInfo()
-            job_info.job_id = hq_job_dict["id"]
+            job_info.job_id = str(hq_job_dict["id"])    # must be str, if it is a int job will not waiting
             job_info.title = hq_job_dict["name"]
             stats: t.List[str] = [
                 stat for stat, v in hq_job_dict["task_stats"].items() if v > 0

--- a/aiida_hyperqueue/scheduler.py
+++ b/aiida_hyperqueue/scheduler.py
@@ -228,7 +228,9 @@ class HyperQueueScheduler(Scheduler):
         job_info_list = []
         for hq_job_dict in hq_job_info_list:
             job_info = JobInfo()
-            job_info.job_id = str(hq_job_dict["id"])    # must be str, if it is a int job will not waiting
+            job_info.job_id = str(
+                hq_job_dict["id"]
+            )  # must be str, if it is a int job will not waiting
             job_info.title = hq_job_dict["name"]
             stats: t.List[str] = [
                 stat for stat, v in hq_job_dict["task_stats"].items() if v > 0


### PR DESCRIPTION
fixes #29

The id field of JobInfo is expecting a str. In #24 when parsing JSON output of `hq job list` the json loads will use the int for the id parsed directly. Wrong type causes the subtle issue that when job is waiting it not get into QUEUED state, but immediatly finished and get nothing to parse from output.