### PR TITLE
Use num_machines * num_mpiprocs_per_machines to set num_cpus

### DIFF
--- a/aiida_hyperqueue/scheduler.py
+++ b/aiida_hyperqueue/scheduler.py
@@ -26,9 +26,9 @@ _MAP_STATUS_HYPERQUEUE = {
     "FINISHED": JobState.DONE,
 }
 
+
 class AiiDAHypereQueueDeprecationWarning(Warning):
-    """Class for HypereQueue plugin deprecations.
-    """
+    """Class for HypereQueue plugin deprecations."""
 
 
 class HyperQueueJobResource(JobResource):
@@ -65,9 +65,9 @@ class HyperQueueJobResource(JobResource):
             try:
                 # For backward compatibility where `num_machines` and `num_mpiprocs_per_machine` are setting
                 # TODO: I only setting the default value as 1 for `num_mpiprocs_per_machine` because aiida-quantumespresso override
-                # resources default with `num_machines` set to 1 and then get builder with such setting. 
+                # resources default with `num_machines` set to 1 and then get builder with such setting.
                 # The `num_mpiprocs_per_machine` sometime can be read from "Default #procs/machine" of computer setup but if it is not exist
-                # the builder can not be properly get without passing `option` to builder generator. 
+                # the builder can not be properly get without passing `option` to builder generator.
                 # It is anyway a workaround for backward compatibility so this default is implemented despite it is quite specific for the qe plugin.
                 resources.num_cpus = kwargs.pop("num_machines") * kwargs.pop(
                     "num_mpiprocs_per_machine", 1
@@ -77,10 +77,10 @@ class HyperQueueJobResource(JobResource):
                     "Must specify `num_cpus`, or (`num_machines` and `num_mpiprocs_per_machine`)"
                 )
             else:
-                message = 'The `num_machines` and `num_mpiprocs_per_machine` for setting hyperqueue resources are deprecated. '
-                'Please set `num_cpus` and `memory_mb`.'
+                message = "The `num_machines` and `num_mpiprocs_per_machine` for setting hyperqueue resources are deprecated. "
+                "Please set `num_cpus` and `memory_mb`."
 
-                message = f'{message} (this will be removed in aiida-hyperqueue v1.0)'
+                message = f"{message} (this will be removed in aiida-hyperqueue v1.0)"
                 warnings.warn(message, AiiDAHypereQueueDeprecationWarning, stacklevel=3)
         else:
             if not isinstance(resources.num_cpus, int):

--- a/aiida_hyperqueue/scheduler.py
+++ b/aiida_hyperqueue/scheduler.py
@@ -57,7 +57,10 @@ class HyperQueueJobResource(JobResource):
         try:
             resources.num_cpus = kwargs.pop("num_cpus")
         except KeyError:
-            raise KeyError("Must specify `num_cpus`")
+            try:
+                resources.num_cpus = kwargs.pop("num_machines") * kwargs.pop("num_mpiprocs_per_machine")
+            except KeyError:
+                raise KeyError(f"Must specify `num_cpus`, or (`num_machines` and `num_mpiprocs_per_machine`) {kwargs}")
         else:
             if not isinstance(resources.num_cpus, int):
                 raise ValueError("`num_cpus` must be an integer")

--- a/aiida_hyperqueue/scheduler.py
+++ b/aiida_hyperqueue/scheduler.py
@@ -29,7 +29,7 @@ _MAP_STATUS_HYPERQUEUE = {
 class HyperQueueJobResource(JobResource):
     """Class for HyperQueue job resources."""
 
-    _default_fields = ("num_cpus", "memory_mb")
+    _default_fields = ("num_cpus", "memory_mb", "num_machines", "num_mpiprocs_per_machine")
 
     _features = {
         "can_query_by_user": False,
@@ -58,9 +58,13 @@ class HyperQueueJobResource(JobResource):
             resources.num_cpus = kwargs.pop("num_cpus")
         except KeyError:
             try:
-                resources.num_cpus = kwargs.pop("num_machines") * kwargs.pop("num_mpiprocs_per_machine")
+                resources.num_cpus = kwargs.pop("num_machines") * kwargs.pop(
+                    "num_mpiprocs_per_machine"
+                )
             except KeyError:
-                raise KeyError(f"Must specify `num_cpus`, or (`num_machines` and `num_mpiprocs_per_machine`) {kwargs}")
+                raise KeyError(
+                    f"Must specify `num_cpus`, or (`num_machines` and `num_mpiprocs_per_machine`) {kwargs}"
+                )
         else:
             if not isinstance(resources.num_cpus, int):
                 raise ValueError("`num_cpus` must be an integer")

--- a/aiida_hyperqueue/scheduler.py
+++ b/aiida_hyperqueue/scheduler.py
@@ -64,7 +64,12 @@ class HyperQueueJobResource(JobResource):
         except KeyError:
             try:
                 # For backward compatibility where `num_machines` and `num_mpiprocs_per_machine` are setting
-                resources.num_cpus = kwargs.pop("num_machines", 1) * kwargs.pop(
+                # TODO: I only setting the default value as 1 for `num_mpiprocs_per_machine` because aiida-quantumespresso override
+                # resources default with `num_machines` set to 1 and then get builder with such setting. 
+                # The `num_mpiprocs_per_machine` sometime can be read from "Default #procs/machine" of computer setup but if it is not exist
+                # the builder can not be properly get without passing `option` to builder generator. 
+                # It is anyway a workaround for backward compatibility so this default is implemented despite it is quite specific for the qe plugin.
+                resources.num_cpus = kwargs.pop("num_machines") * kwargs.pop(
                     "num_mpiprocs_per_machine", 1
                 )
             except KeyError:


### PR DESCRIPTION
For backward compatibility where `num_machines` and `num_mpiprocs_per_machine` are setting.

I only setting the default value as 1 for `num_mpiprocs_per_machine` because `aiida-quantumespresso` override
resources default with `num_machines` set to 1 and then get builder with such setting.
The `num_mpiprocs_per_machine` sometime can be read from "Default #procs/machine" of computer setup but if it is not exist the builder can not be properly get without passing `option` to builder generator.
It is anyway a workaround for backward compatibility so this default is implemented despite it is quite specific for the qe plugin.